### PR TITLE
deployment now properly hands '-' in emitted code by converting it to…

### DIFF
--- a/codify/clusterrole.go
+++ b/codify/clusterrole.go
@@ -57,7 +57,7 @@ func (k ClusterRole) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/clusterrolebinding.go
+++ b/codify/clusterrolebinding.go
@@ -57,7 +57,7 @@ func (k ClusterRoleBinding) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/codify.go
+++ b/codify/codify.go
@@ -138,7 +138,7 @@ func alias(generated, defaultalias string) string {
 }
 
 func varName(name string) string {
-	reg, _ := regexp.Compile("[^a-zA-Z0-9 ]+")
+	reg, _ := regexp.Compile("[^a-zA-Z0-9 \\-]+")
 	return reg.ReplaceAllString(name, "")
 }
 

--- a/codify/codify.go
+++ b/codify/codify.go
@@ -137,7 +137,7 @@ func alias(generated, defaultalias string) string {
 	return aliased
 }
 
-func varName(name string) string {
+func sanitizeK8sObjectName(name string) string {
 	reg, _ := regexp.Compile("[^a-zA-Z0-9 \\-]+")
 	return reg.ReplaceAllString(name, "")
 }

--- a/codify/configmap.go
+++ b/codify/configmap.go
@@ -57,7 +57,7 @@ func (k ConfigMap) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/cronjob.go
+++ b/codify/cronjob.go
@@ -58,7 +58,7 @@ func (k CronJob) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/daemonset.go
+++ b/codify/daemonset.go
@@ -74,7 +74,7 @@ func (k DaemonSet) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/deployment.go
+++ b/codify/deployment.go
@@ -28,28 +28,32 @@ import (
 	"fmt"
 	"github.com/kris-nova/logger"
 	appsv1 "k8s.io/api/apps/v1"
+	"strings"
 	"text/template"
 	"time"
 )
 
 type Deployment struct {
-	i *appsv1.Deployment
+	*appsv1.Deployment
+	GoName string
 }
 
 func NewDeployment(obj *appsv1.Deployment) *Deployment {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = appsv1.DeploymentStatus{}
 	return &Deployment{
-		i: obj,
+		Deployment: obj,
+		GoName:     strings.ReplaceAll(obj.Name, "-", "_"),
 	}
 }
 
 func (k Deployment) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.Deployment)
 	install := fmt.Sprintf(`
-	{{ .Name }}Deployment := %s
+	// Adding a deployment: "{{ .Name }}"
+	{{ .GoName }}Deployment := %s
 
-	_, err = client.AppsV1().Deployments("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}Deployment, v1.CreateOptions{})
+	_, err = client.AppsV1().Deployments("{{ .Namespace }}").Create(context.TODO(), {{ .GoName }}Deployment, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -57,7 +61,7 @@ func (k Deployment) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -74,8 +78,8 @@ func (k Deployment) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.Name = varName(k.Name)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/deployment.go
+++ b/codify/deployment.go
@@ -78,7 +78,7 @@ func (k Deployment) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	k.KubeObject.Name = varName(k.KubeObject.Name)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
 	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/ingress.go
+++ b/codify/ingress.go
@@ -57,7 +57,7 @@ func (k Ingress) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/job.go
+++ b/codify/job.go
@@ -58,7 +58,7 @@ func (k Job) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/persistentvolume.go
+++ b/codify/persistentvolume.go
@@ -58,7 +58,7 @@ func (k PersistentVolume) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/persistentvolumeclaim.go
+++ b/codify/persistentvolumeclaim.go
@@ -58,7 +58,7 @@ func (k PersistentVolumeClaim) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/pod.go
+++ b/codify/pod.go
@@ -57,7 +57,7 @@ func (k Pod) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/role.go
+++ b/codify/role.go
@@ -57,7 +57,7 @@ func (k Role) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/rolebinding.go
+++ b/codify/rolebinding.go
@@ -57,7 +57,7 @@ func (k RoleBinding) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/secret.go
+++ b/codify/secret.go
@@ -57,7 +57,7 @@ func (k Secret) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/service.go
+++ b/codify/service.go
@@ -58,7 +58,7 @@ func (k Service) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/serviceaccount.go
+++ b/codify/serviceaccount.go
@@ -57,7 +57,7 @@ func (k ServiceAccount) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/codify/statefulset.go
+++ b/codify/statefulset.go
@@ -74,7 +74,7 @@ func (k StatefulSet) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	k.i.Name = varName(k.i.Name)
+	k.i.Name = sanitizeK8sObjectName(k.i.Name)
 	err := tpl.Execute(buf, k.i)
 	if err != nil {
 		logger.Debug(err.Error())

--- a/go.sum
+++ b/go.sum
@@ -184,7 +184,9 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hexops/autogold v0.8.1 h1:wvyd/bAJ+Dy+DcE09BoLk6r4Fa5R5W+O+GUzmR985WM=
 github.com/hexops/autogold v0.8.1/go.mod h1:97HLDXyG23akzAoRYJh/2OBs3kd80eHyKPvZw0S5ZBY=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hexops/valast v1.4.0 h1:sFzyxPDP0riFQUzSBXTCCrAbbIndHPWMndxuEjXdZlc=
 github.com/hexops/valast v1.4.0/go.mod h1:uVjKZ0smVuYlgCSPz9NRi5A04sl7lp6GtFWsROKDgEs=


### PR DESCRIPTION
This PR includes four changes:

* Add GoName to codify.Deployment which represents a golang safe name for our variable.
* appsv1.Deployment is now an embedded type in codify.Deployment. This allows for easier binding to mix `{{ .Name }}` and `{{ .GoName }}` in a single template.
* The template now binds against `{{ .GoName }}` for go variables.
* go mod tidy added a couple things to go.sum. My go version is go1.16.6, in case this makes a difference.

Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>