### PR TITLE
use goname pattern in clusterrole

### DIFF
--- a/codify/clusterrole.go
+++ b/codify/clusterrole.go
@@ -50,7 +50,7 @@ func (k ClusterRole) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}ClusterRole := %s
 
-	_, err = client.RbacV1().ClusterRoles("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ClusterRole, v1.CreateOptions{})
+	_, err = client.RbacV1().ClusterRoles("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}ClusterRole, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/codify.go
+++ b/codify/codify.go
@@ -143,3 +143,7 @@ func sanitizeK8sObjectName(name string) string {
 	reg, _ := regexp.Compile("[^a-zA-Z0-9 \\-]+")
 	return reg.ReplaceAllString(name, "")
 }
+
+func goName(name string) string {
+	return strings.ReplaceAll(name, "-", "_")
+}

--- a/codify/deployment.go
+++ b/codify/deployment.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"github.com/kris-nova/logger"
 	appsv1 "k8s.io/api/apps/v1"
-	"strings"
 	"text/template"
 	"time"
 )
@@ -43,7 +42,7 @@ func NewDeployment(obj *appsv1.Deployment) *Deployment {
 	obj.Status = appsv1.DeploymentStatus{}
 	return &Deployment{
 		KubeObject: obj,
-		GoName:     strings.ReplaceAll(obj.Name, "-", "_"),
+		GoName:     goName(obj.Name),
 	}
 }
 


### PR DESCRIPTION
ClusterRole now follows goname pattern that was set in Deployments.

Also extracts goName into its own method for simplifcation.

Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>