### PR TITLE
Refactor codify structs to use KubeObject and GoName

### DIFF
--- a/codify/clusterrole.go
+++ b/codify/clusterrole.go
@@ -41,7 +41,7 @@ func NewClusterRole(obj *rbacv1.ClusterRole) *ClusterRole {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ClusterRole{
 		KubeObject: obj,
-		GoName: goName(obj.Name),
+		GoName:     goName(obj.Name),
 	}
 }
 

--- a/codify/clusterrole.go
+++ b/codify/clusterrole.go
@@ -50,7 +50,7 @@ func (k ClusterRole) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}ClusterRole := %s
 
-	_, err = client.RbacV1().ClusterRoles("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ClusterRole, v1.CreateOptions{})
+	_, err = client.RbacV1().ClusterRoles("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}ClusterRole, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/clusterrolebinding.go
+++ b/codify/clusterrolebinding.go
@@ -33,18 +33,18 @@ import (
 )
 
 type ClusterRoleBinding struct {
-	i *rbacv1.ClusterRoleBinding
+	KubeObject *rbacv1.ClusterRoleBinding
 }
 
 func NewClusterRoleBinding(obj *rbacv1.ClusterRoleBinding) *ClusterRoleBinding {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ClusterRoleBinding{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k ClusterRoleBinding) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}ClusterRoleBinding := %s
 
@@ -57,8 +57,8 @@ func (k ClusterRoleBinding) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k ClusterRoleBinding) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/clusterrolebinding.go
+++ b/codify/clusterrolebinding.go
@@ -34,21 +34,23 @@ import (
 
 type ClusterRoleBinding struct {
 	KubeObject *rbacv1.ClusterRoleBinding
+	GoName     string
 }
 
 func NewClusterRoleBinding(obj *rbacv1.ClusterRoleBinding) *ClusterRoleBinding {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ClusterRoleBinding{
 		KubeObject: obj,
+		GoName:     goName(obj.Name),
 	}
 }
 
 func (k ClusterRoleBinding) Install() string {
 	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
-	{{ .Name }}ClusterRoleBinding := %s
+	{{ .GoName }}ClusterRoleBinding := %s
 
-	_, err = client.RbacV1().ClusterRoleBindings("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}ClusterRoleBinding, v1.CreateOptions{})
+	_, err = client.RbacV1().ClusterRoleBindings("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ClusterRoleBinding, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func (k ClusterRoleBinding) Install() string {
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
 	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -67,7 +69,7 @@ func (k ClusterRoleBinding) Install() string {
 
 func (k ClusterRoleBinding) Uninstall() string {
 	uninstall := `
-	err = client.RbacV1().ClusterRoleBindings("{{ .Namespace }}").Delete(context.TODO(), "{{ .Name }}", metav1.DeleteOptions{})
+	err = client.RbacV1().ClusterRoleBindings("{{ .KubeObject.Namespace }}").Delete(context.TODO(), "{{ .KubeObject.Name }}", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -75,7 +77,7 @@ func (k ClusterRoleBinding) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/clusterrolebinding.go
+++ b/codify/clusterrolebinding.go
@@ -50,7 +50,7 @@ func (k ClusterRoleBinding) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}ClusterRoleBinding := %s
 
-	_, err = client.RbacV1().ClusterRoleBindings("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ClusterRoleBinding, v1.CreateOptions{})
+	_, err = client.RbacV1().ClusterRoleBindings("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}ClusterRoleBinding, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/codify.go
+++ b/codify/codify.go
@@ -143,3 +143,7 @@ func sanitizeK8sObjectName(name string) string {
 	reg, _ := regexp.Compile("[^a-zA-Z0-9 \\-]+")
 	return reg.ReplaceAllString(name, "")
 }
+
+func goName(name string) string {
+	return strings.ReplaceAll(name, "-", "_")
+}

--- a/codify/configmap.go
+++ b/codify/configmap.go
@@ -34,21 +34,23 @@ import (
 
 type ConfigMap struct {
 	KubeObject *corev1.ConfigMap
+	GoName     string
 }
 
 func NewConfigMap(obj *corev1.ConfigMap) *ConfigMap {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ConfigMap{
 		KubeObject: obj,
+		GoName:     goName(obj.Name),
 	}
 }
 
 func (k ConfigMap) Install() string {
 	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
-	{{ .Name }}ConfigMap := %s
+	{{ .GoName }}ConfigMap := %s
 
-	_, err = client.CoreV1().ConfigMaps("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}ConfigMap, v1.CreateOptions{})
+	_, err = client.CoreV1().ConfigMaps("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ConfigMap, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func (k ConfigMap) Install() string {
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
 	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -67,7 +69,7 @@ func (k ConfigMap) Install() string {
 
 func (k ConfigMap) Uninstall() string {
 	uninstall := `
-	err = client.CoreV1().ConfigMaps("{{ .Namespace }}").Delete(context.TODO(), "{{ .Name }}", metav1.DeleteOptions{})
+	err = client.CoreV1().ConfigMaps("{{ .KubeObject.Namespace }}").Delete(context.TODO(), "{{ .KubeObject.Name }}", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -75,7 +77,7 @@ func (k ConfigMap) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/configmap.go
+++ b/codify/configmap.go
@@ -50,7 +50,7 @@ func (k ConfigMap) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}ConfigMap := %s
 
-	_, err = client.CoreV1().ConfigMaps("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ConfigMap, v1.CreateOptions{})
+	_, err = client.CoreV1().ConfigMaps("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}ConfigMap, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/configmap.go
+++ b/codify/configmap.go
@@ -33,18 +33,18 @@ import (
 )
 
 type ConfigMap struct {
-	i *corev1.ConfigMap
+	KubeObject *corev1.ConfigMap
 }
 
 func NewConfigMap(obj *corev1.ConfigMap) *ConfigMap {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ConfigMap{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k ConfigMap) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}ConfigMap := %s
 
@@ -57,8 +57,8 @@ func (k ConfigMap) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k ConfigMap) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/cronjob.go
+++ b/codify/cronjob.go
@@ -33,19 +33,19 @@ import (
 )
 
 type CronJob struct {
-	i *batchv1.CronJob
+	KubeObject *batchv1.CronJob
 }
 
 func NewCronJob(obj *batchv1.CronJob) *CronJob {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = batchv1.CronJobStatus{}
 	return &CronJob{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k CronJob) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}CronJob := %s
 
@@ -58,8 +58,8 @@ func (k CronJob) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -76,7 +76,7 @@ func (k CronJob) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/cronjob.go
+++ b/codify/cronjob.go
@@ -51,7 +51,7 @@ func (k CronJob) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}CronJob := %s
 
-	_, err = client.BatchV1().CronJobs("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}CronJob, v1.CreateOptions{})
+	_, err = client.BatchV1().CronJobs("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}CronJob, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/daemonset.go
+++ b/codify/daemonset.go
@@ -33,19 +33,19 @@ import (
 )
 
 type DaemonSet struct {
-	i *appsv1.DaemonSet
+	KubeObject *appsv1.DaemonSet
 }
 
 func NewDaemonSet(obj *appsv1.DaemonSet) *DaemonSet {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = appsv1.DaemonSetStatus{}
 	return &DaemonSet{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k DaemonSet) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}DaemonSet := %s
 
@@ -57,7 +57,7 @@ func (k DaemonSet) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -74,8 +74,8 @@ func (k DaemonSet) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/daemonset.go
+++ b/codify/daemonset.go
@@ -51,7 +51,7 @@ func (k DaemonSet) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}DaemonSet := %s
 
-	_, err = client.AppsV1().DaemonSets("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Deployment, v1.CreateOptions{})
+	_, err = client.AppsV1().DaemonSets("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Deployment, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/deployment.go
+++ b/codify/deployment.go
@@ -34,7 +34,7 @@ import (
 
 type Deployment struct {
 	KubeObject *appsv1.Deployment
-	GoName string
+	GoName     string
 }
 
 func NewDeployment(obj *appsv1.Deployment) *Deployment {

--- a/codify/deployment.go
+++ b/codify/deployment.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"github.com/kris-nova/logger"
 	appsv1 "k8s.io/api/apps/v1"
-	"strings"
 	"text/template"
 	"time"
 )
@@ -43,7 +42,7 @@ func NewDeployment(obj *appsv1.Deployment) *Deployment {
 	obj.Status = appsv1.DeploymentStatus{}
 	return &Deployment{
 		KubeObject: obj,
-		GoName:     strings.ReplaceAll(obj.Name, "-", "_"),
+		GoName:     goName(obj.Name),
 	}
 }
 

--- a/codify/ingress.go
+++ b/codify/ingress.go
@@ -50,7 +50,7 @@ func (k Ingress) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}Ingress := %s
 
-	_, err = client.NetworkingV1().Ingresss("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Ingress, v1.CreateOptions{})
+	_, err = client.NetworkingV1().Ingresss("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Ingress, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/ingress.go
+++ b/codify/ingress.go
@@ -33,18 +33,18 @@ import (
 )
 
 type Ingress struct {
-	i *networkingv1.Ingress
+	KubeObject *networkingv1.Ingress
 }
 
 func NewIngress(obj *networkingv1.Ingress) *Ingress {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &Ingress{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k Ingress) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}Ingress := %s
 
@@ -57,8 +57,8 @@ func (k Ingress) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k Ingress) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/job.go
+++ b/codify/job.go
@@ -33,19 +33,19 @@ import (
 )
 
 type Job struct {
-	i *batchv1.Job
+	KubeObject *batchv1.Job
 }
 
 func NewJob(obj *batchv1.Job) *Job {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = batchv1.JobStatus{}
 	return &Job{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k Job) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}Job := %s
 
@@ -58,8 +58,8 @@ func (k Job) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -76,7 +76,7 @@ func (k Job) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/job.go
+++ b/codify/job.go
@@ -51,7 +51,7 @@ func (k Job) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}Job := %s
 
-	_, err = client.BatchV1().Jobs("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Job, v1.CreateOptions{})
+	_, err = client.BatchV1().Jobs("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Job, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/persistentvolume.go
+++ b/codify/persistentvolume.go
@@ -33,19 +33,19 @@ import (
 )
 
 type PersistentVolume struct {
-	i *corev1.PersistentVolume
+	KubeObject *corev1.PersistentVolume
 }
 
 func NewPersistentVolume(obj *corev1.PersistentVolume) *PersistentVolume {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = corev1.PersistentVolumeStatus{}
 	return &PersistentVolume{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k PersistentVolume) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}PersistentVolume := %s
 
@@ -58,8 +58,8 @@ func (k PersistentVolume) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -76,7 +76,7 @@ func (k PersistentVolume) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/persistentvolume.go
+++ b/codify/persistentvolume.go
@@ -51,7 +51,7 @@ func (k PersistentVolume) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}PersistentVolume := %s
 
-	_, err = client.CoreV1().PersistentVolumes("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}PersistentVolume, v1.CreateOptions{})
+	_, err = client.CoreV1().PersistentVolumes("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}PersistentVolume, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/persistentvolumeclaim.go
+++ b/codify/persistentvolumeclaim.go
@@ -51,7 +51,7 @@ func (k PersistentVolumeClaim) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}PersistentVolumeClaim := %s
 
-	_, err = client.CoreV1().PersistentVolumeClaims("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}PersistentVolumeClaim, v1.CreateOptions{})
+	_, err = client.CoreV1().PersistentVolumeClaims("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}PersistentVolumeClaim, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/persistentvolumeclaim.go
+++ b/codify/persistentvolumeclaim.go
@@ -34,6 +34,7 @@ import (
 
 type PersistentVolumeClaim struct {
 	KubeObject *corev1.PersistentVolumeClaim
+	GoName     string
 }
 
 func NewPersistentVolumeClaim(obj *corev1.PersistentVolumeClaim) *PersistentVolumeClaim {
@@ -41,15 +42,16 @@ func NewPersistentVolumeClaim(obj *corev1.PersistentVolumeClaim) *PersistentVolu
 	obj.Status = corev1.PersistentVolumeClaimStatus{}
 	return &PersistentVolumeClaim{
 		KubeObject: obj,
+		GoName:     goName(obj.Name),
 	}
 }
 
 func (k PersistentVolumeClaim) Install() string {
 	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
-	{{ .Name }}PersistentVolumeClaim := %s
+	{{ .GoName }}PersistentVolumeClaim := %s
 
-	_, err = client.CoreV1().PersistentVolumeClaims("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}PersistentVolumeClaim, v1.CreateOptions{})
+	_, err = client.CoreV1().PersistentVolumeClaims("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}PersistentVolumeClaim, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -59,7 +61,7 @@ func (k PersistentVolumeClaim) Install() string {
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
 	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -68,7 +70,7 @@ func (k PersistentVolumeClaim) Install() string {
 
 func (k PersistentVolumeClaim) Uninstall() string {
 	uninstall := `
-	err = client.CoreV1().PersistentVolumeClaims("{{ .Namespace }}").Delete(context.TODO(), "{{ .Name }}", metav1.DeleteOptions{})
+	err = client.CoreV1().PersistentVolumeClaims("{{ .KubeObject.Namespace }}").Delete(context.TODO(), "{{ .KubeObject.Name }}", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -76,7 +78,7 @@ func (k PersistentVolumeClaim) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/persistentvolumeclaim.go
+++ b/codify/persistentvolumeclaim.go
@@ -33,19 +33,19 @@ import (
 )
 
 type PersistentVolumeClaim struct {
-	i *corev1.PersistentVolumeClaim
+	KubeObject *corev1.PersistentVolumeClaim
 }
 
 func NewPersistentVolumeClaim(obj *corev1.PersistentVolumeClaim) *PersistentVolumeClaim {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = corev1.PersistentVolumeClaimStatus{}
 	return &PersistentVolumeClaim{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k PersistentVolumeClaim) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}PersistentVolumeClaim := %s
 
@@ -58,8 +58,8 @@ func (k PersistentVolumeClaim) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -76,7 +76,7 @@ func (k PersistentVolumeClaim) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/pod.go
+++ b/codify/pod.go
@@ -51,7 +51,7 @@ func (k Pod) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}Pod := %s
 
-	_, err = client.CoreV1().Pods("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Pod, v1.CreateOptions{})
+	_, err = client.CoreV1().Pods("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Pod, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/pod.go
+++ b/codify/pod.go
@@ -34,6 +34,7 @@ import (
 
 type Pod struct {
 	KubeObject *corev1.Pod
+	GoName     string
 }
 
 func NewPod(obj *corev1.Pod) *Pod {
@@ -41,15 +42,16 @@ func NewPod(obj *corev1.Pod) *Pod {
 	obj.Status = corev1.PodStatus{}
 	return &Pod{
 		KubeObject: obj,
+		GoName:     goName(obj.Name),
 	}
 }
 
 func (k Pod) Install() string {
 	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
-	{{ .Name }}Pod := %s
+	{{ .GoName }}Pod := %s
 
-	_, err = client.CoreV1().Pods("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}Pod, v1.CreateOptions{})
+	_, err = client.CoreV1().Pods("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Pod, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func (k Pod) Install() string {
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
 	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -67,7 +69,7 @@ func (k Pod) Install() string {
 
 func (k Pod) Uninstall() string {
 	uninstall := `
-	err = client.CoreV1().Pods("{{ .Namespace }}").Delete(context.TODO(), "{{ .Name }}", metav1.DeleteOptions{})
+	err = client.CoreV1().Pods("{{ .KubeObject.Namespace }}").Delete(context.TODO(), "{{ .KubeObject.Name }}", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -75,7 +77,7 @@ func (k Pod) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/pod.go
+++ b/codify/pod.go
@@ -33,19 +33,19 @@ import (
 )
 
 type Pod struct {
-	i *corev1.Pod
+	KubeObject *corev1.Pod
 }
 
 func NewPod(obj *corev1.Pod) *Pod {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = corev1.PodStatus{}
 	return &Pod{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k Pod) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}Pod := %s
 
@@ -57,8 +57,8 @@ func (k Pod) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k Pod) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/role.go
+++ b/codify/role.go
@@ -33,18 +33,18 @@ import (
 )
 
 type Role struct {
-	i *rbacv1.Role
+	KubeObject *rbacv1.Role
 }
 
 func NewRole(obj *rbacv1.Role) *Role {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &Role{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k Role) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}Role := %s
 
@@ -57,8 +57,8 @@ func (k Role) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k Role) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/role.go
+++ b/codify/role.go
@@ -50,7 +50,7 @@ func (k Role) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}Role := %s
 
-	_, err = client.RbacV1().Roles("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Role, v1.CreateOptions{})
+	_, err = client.RbacV1().Roles("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Role, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/rolebinding.go
+++ b/codify/rolebinding.go
@@ -50,7 +50,7 @@ func (k RoleBinding) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}RoleBinding := %s
 
-	_, err = client.RbacV1().RoleBindings("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}RoleBinding, v1.CreateOptions{})
+	_, err = client.RbacV1().RoleBindings("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}RoleBinding, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/rolebinding.go
+++ b/codify/rolebinding.go
@@ -33,18 +33,18 @@ import (
 )
 
 type RoleBinding struct {
-	i *rbacv1.RoleBinding
+	KubeObject *rbacv1.RoleBinding
 }
 
 func NewRoleBinding(obj *rbacv1.RoleBinding) *RoleBinding {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &RoleBinding{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k RoleBinding) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}RoleBinding := %s
 
@@ -57,8 +57,8 @@ func (k RoleBinding) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k RoleBinding) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/secret.go
+++ b/codify/secret.go
@@ -50,7 +50,7 @@ func (k Secret) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}Secret := %s
 
-	_, err = client.CoreV1().Secrets("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Secret, v1.CreateOptions{})
+	_, err = client.CoreV1().Secrets("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Secret, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/secret.go
+++ b/codify/secret.go
@@ -33,18 +33,18 @@ import (
 )
 
 type Secret struct {
-	i *corev1.Secret
+	KubeObject *corev1.Secret
 }
 
 func NewSecret(obj *corev1.Secret) *Secret {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &Secret{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k Secret) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}Secret := %s
 
@@ -57,8 +57,8 @@ func (k Secret) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k Secret) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/service.go
+++ b/codify/service.go
@@ -34,6 +34,7 @@ import (
 
 type Service struct {
 	KubeObject *corev1.Service
+	GoName     string
 }
 
 func NewService(obj *corev1.Service) *Service {
@@ -41,15 +42,16 @@ func NewService(obj *corev1.Service) *Service {
 	obj.Status = corev1.ServiceStatus{}
 	return &Service{
 		KubeObject: obj,
+		GoName:     goName(obj.Name),
 	}
 }
 
 func (k Service) Install() string {
 	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
-	{{ .Name }}Service := %s
+	{{ .GoName }}Service := %s
 
-	_, err = client.CoreV1().Services("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}Service, v1.CreateOptions{})
+	_, err = client.CoreV1().Services("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Service, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -59,7 +61,7 @@ func (k Service) Install() string {
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
 	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -68,7 +70,7 @@ func (k Service) Install() string {
 
 func (k Service) Uninstall() string {
 	uninstall := `
-	err = client.CoreV1().Services("{{ .Namespace }}").Delete(context.TODO(), "{{ .Name }}", metav1.DeleteOptions{})
+	err = client.CoreV1().Services("{{ .KubeObject.Namespace }}").Delete(context.TODO(), "{{ .KubeObject.Name }}", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -76,7 +78,7 @@ func (k Service) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/service.go
+++ b/codify/service.go
@@ -33,19 +33,19 @@ import (
 )
 
 type Service struct {
-	i *corev1.Service
+	KubeObject *corev1.Service
 }
 
 func NewService(obj *corev1.Service) *Service {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = corev1.ServiceStatus{}
 	return &Service{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k Service) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}Service := %s
 
@@ -58,8 +58,8 @@ func (k Service) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -76,7 +76,7 @@ func (k Service) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/service.go
+++ b/codify/service.go
@@ -51,7 +51,7 @@ func (k Service) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}Service := %s
 
-	_, err = client.CoreV1().Services("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Service, v1.CreateOptions{})
+	_, err = client.CoreV1().Services("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Service, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/serviceaccount.go
+++ b/codify/serviceaccount.go
@@ -33,18 +33,18 @@ import (
 )
 
 type ServiceAccount struct {
-	i *corev1.ServiceAccount
+	KubeObject *corev1.ServiceAccount
 }
 
 func NewServiceAccount(obj *corev1.ServiceAccount) *ServiceAccount {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ServiceAccount{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k ServiceAccount) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}ServiceAccount := %s
 
@@ -57,8 +57,8 @@ func (k ServiceAccount) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -75,7 +75,7 @@ func (k ServiceAccount) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/serviceaccount.go
+++ b/codify/serviceaccount.go
@@ -50,7 +50,7 @@ func (k ServiceAccount) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}ServiceAccount := %s
 
-	_, err = client.CoreV1().ServiceAccounts("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ServiceAccount, v1.CreateOptions{})
+	_, err = client.CoreV1().ServiceAccounts("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}ServiceAccount, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/codify/serviceaccount.go
+++ b/codify/serviceaccount.go
@@ -34,21 +34,23 @@ import (
 
 type ServiceAccount struct {
 	KubeObject *corev1.ServiceAccount
+	GoName     string
 }
 
 func NewServiceAccount(obj *corev1.ServiceAccount) *ServiceAccount {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	return &ServiceAccount{
 		KubeObject: obj,
+		GoName:     goName(obj.Name),
 	}
 }
 
 func (k ServiceAccount) Install() string {
 	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
-	{{ .Name }}ServiceAccount := %s
+	{{ .GoName }}ServiceAccount := %s
 
-	_, err = client.CoreV1().ServiceAccounts("{{ .Namespace }}").Create(context.TODO(), {{ .Name }}ServiceAccount, v1.CreateOptions{})
+	_, err = client.CoreV1().ServiceAccounts("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}ServiceAccount, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +60,7 @@ func (k ServiceAccount) Install() string {
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
 	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -67,7 +69,7 @@ func (k ServiceAccount) Install() string {
 
 func (k ServiceAccount) Uninstall() string {
 	uninstall := `
-	err = client.CoreV1().ServiceAccounts("{{ .Namespace }}").Delete(context.TODO(), "{{ .Name }}", metav1.DeleteOptions{})
+	err = client.CoreV1().ServiceAccounts("{{ .KubeObject.Namespace }}").Delete(context.TODO(), "{{ .KubeObject.Name }}", metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
@@ -75,7 +77,7 @@ func (k ServiceAccount) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.KubeObject)
+	err := tpl.Execute(buf, k)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/statefulset.go
+++ b/codify/statefulset.go
@@ -33,19 +33,19 @@ import (
 )
 
 type StatefulSet struct {
-	i *appsv1.StatefulSet
+	KubeObject *appsv1.StatefulSet
 }
 
 func NewStatefulSet(obj *appsv1.StatefulSet) *StatefulSet {
 	obj.ObjectMeta = cleanObjectMeta(obj.ObjectMeta)
 	obj.Status = appsv1.StatefulSetStatus{}
 	return &StatefulSet{
-		i: obj,
+		KubeObject: obj,
 	}
 }
 
 func (k StatefulSet) Install() string {
-	l := Literal(k.i)
+	l := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .Name }}StatefulSet := %s
 
@@ -57,7 +57,7 @@ func (k StatefulSet) Install() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(install)
 	buf := &bytes.Buffer{}
-	err := tpl.Execute(buf, k.i)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}
@@ -74,8 +74,8 @@ func (k StatefulSet) Uninstall() string {
 	tpl := template.New(fmt.Sprintf("%s", time.Now().String()))
 	tpl.Parse(uninstall)
 	buf := &bytes.Buffer{}
-	k.i.Name = sanitizeK8sObjectName(k.i.Name)
-	err := tpl.Execute(buf, k.i)
+	k.KubeObject.Name = sanitizeK8sObjectName(k.KubeObject.Name)
+	err := tpl.Execute(buf, k.KubeObject)
 	if err != nil {
 		logger.Debug(err.Error())
 	}

--- a/codify/statefulset.go
+++ b/codify/statefulset.go
@@ -51,7 +51,7 @@ func (k StatefulSet) Install() string {
 	install := fmt.Sprintf(`
 	{{ .GoName }}StatefulSet := %s
 
-	_, err = client.AppsV1().StatefulSets("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .KubeObject.Name }}Deployment, v1.CreateOptions{})
+	_, err = client.AppsV1().StatefulSets("{{ .KubeObject.Namespace }}").Create(context.TODO(), {{ .GoName }}Deployment, v1.CreateOptions{})
 	if err != nil {
 		return err
 	}

--- a/embed_main.go
+++ b/embed_main.go
@@ -64,12 +64,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// Define this version for the current version of your application.
 var Version string = "{{ .Version }}"
 
 func main() {
 	// Load the application into the NAML registery
 	// Note: naml.Register() can be used multiple times.
-	//
 	naml.Register(NewApp("{{ .AppNameTitle }}", "{{ .Description }}"))
 
 	// Run the generic naml command line program with
@@ -81,18 +81,20 @@ func main() {
 	}
 }
 
+// App is a very important grown up business application.
 type App struct {
 	metav1.ObjectMeta
 	description string
-	// --------------------
-	// Add your fields here
-	// --------------------
+	// ----------------------------------
+	// Add your configuration fields here
+	// ----------------------------------
 }
 
 // NewApp will create a new instance of App.
 //
 // See https://github.com/naml-examples for more examples.
 //
+// This is where you pass in fields to your application (similar to Values.yaml)
 // Example: func NewApp(name string, example string, something int) *App
 func NewApp(name, description string) *App {
 	return &App{
@@ -101,9 +103,9 @@ func NewApp(name, description string) *App {
 			Name: name,
 			ResourceVersion: Version,
 		},
-		// --------------------
-		// Add your fields here
-		// --------------------
+	    // ----------------------------------
+	    // Add your configuration fields here
+	    // ----------------------------------
 	}
 }
 


### PR DESCRIPTION
Add KubeObject and GoName to the rest of the structs in the codify package with appropriate changes the templates.