### PR TITLE
codify now dynamically generates package imports

### DIFF
--- a/codify/clusterrole.go
+++ b/codify/clusterrole.go
@@ -46,8 +46,8 @@ func NewClusterRole(obj *rbacv1.ClusterRole) *ClusterRole {
 	}
 }
 
-func (k ClusterRole) Install() string {
-	l := Literal(k.KubeObject)
+func (k ClusterRole) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}ClusterRole := %s
 
@@ -65,7 +65,7 @@ func (k ClusterRole) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "rbacv1")
+	return alias(buf.String(), "rbacv1"), packages
 }
 
 func (k ClusterRole) Uninstall() string {

--- a/codify/clusterrolebinding.go
+++ b/codify/clusterrolebinding.go
@@ -46,8 +46,8 @@ func NewClusterRoleBinding(obj *rbacv1.ClusterRoleBinding) *ClusterRoleBinding {
 	}
 }
 
-func (k ClusterRoleBinding) Install() string {
-	l := Literal(k.KubeObject)
+func (k ClusterRoleBinding) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}ClusterRoleBinding := %s
 
@@ -65,7 +65,7 @@ func (k ClusterRoleBinding) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "rbacv1")
+	return alias(buf.String(), "rbacv1"), packages
 }
 
 func (k ClusterRoleBinding) Uninstall() string {

--- a/codify/codify.go
+++ b/codify/codify.go
@@ -25,6 +25,7 @@ package codify
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -32,9 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Literal(kubeobject interface{}) string {
+func Literal(kubeobject interface{}) (string, []string) {
 	l := valast.String(kubeobject)
-	return l
+	_, packages, _ := valast.ASTWithPackages(reflect.ValueOf(kubeobject), nil)
+	return l, packages
 }
 
 // cleanObjectMeta helps us get rid of things like timestamps

--- a/codify/configmap.go
+++ b/codify/configmap.go
@@ -46,8 +46,8 @@ func NewConfigMap(obj *corev1.ConfigMap) *ConfigMap {
 	}
 }
 
-func (k ConfigMap) Install() string {
-	l := Literal(k.KubeObject)
+func (k ConfigMap) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}ConfigMap := %s
 
@@ -65,7 +65,7 @@ func (k ConfigMap) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k ConfigMap) Uninstall() string {

--- a/codify/cronjob.go
+++ b/codify/cronjob.go
@@ -47,8 +47,8 @@ func NewCronJob(obj *batchv1.CronJob) *CronJob {
 	}
 }
 
-func (k CronJob) Install() string {
-	l := Literal(k.KubeObject)
+func (k CronJob) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}CronJob := %s
 
@@ -66,7 +66,7 @@ func (k CronJob) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "batchv1")
+	return alias(buf.String(), "batchv1"), packages
 }
 
 func (k CronJob) Uninstall() string {

--- a/codify/daemonset.go
+++ b/codify/daemonset.go
@@ -47,8 +47,8 @@ func NewDaemonSet(obj *appsv1.DaemonSet) *DaemonSet {
 	}
 }
 
-func (k DaemonSet) Install() string {
-	l := Literal(k.KubeObject)
+func (k DaemonSet) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}DaemonSet := %s
 
@@ -64,7 +64,7 @@ func (k DaemonSet) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "appsv1")
+	return alias(buf.String(), "appsv1"), packages
 }
 
 func (k DaemonSet) Uninstall() string {

--- a/codify/deployment.go
+++ b/codify/deployment.go
@@ -47,8 +47,8 @@ func NewDeployment(obj *appsv1.Deployment) *Deployment {
 	}
 }
 
-func (k Deployment) Install() string {
-	l := Literal(k.KubeObject)
+func (k Deployment) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	// Adding a deployment: "{{ .KubeObject.Name }}"
 	{{ .GoName }}Deployment := %s
@@ -65,7 +65,7 @@ func (k Deployment) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "appsv1")
+	return alias(buf.String(), "appsv1"), packages
 }
 
 func (k Deployment) Uninstall() string {

--- a/codify/ingress.go
+++ b/codify/ingress.go
@@ -46,8 +46,8 @@ func NewIngress(obj *networkingv1.Ingress) *Ingress {
 	}
 }
 
-func (k Ingress) Install() string {
-	l := Literal(k.KubeObject)
+func (k Ingress) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}Ingress := %s
 
@@ -65,7 +65,7 @@ func (k Ingress) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "networkingv1")
+	return alias(buf.String(), "networkingv1"), packages
 }
 
 func (k Ingress) Uninstall() string {

--- a/codify/job.go
+++ b/codify/job.go
@@ -47,8 +47,8 @@ func NewJob(obj *batchv1.Job) *Job {
 	}
 }
 
-func (k Job) Install() string {
-	l := Literal(k.KubeObject)
+func (k Job) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}Job := %s
 
@@ -66,7 +66,7 @@ func (k Job) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "batchv1")
+	return alias(buf.String(), "batchv1"), packages
 }
 
 func (k Job) Uninstall() string {

--- a/codify/persistentvolume.go
+++ b/codify/persistentvolume.go
@@ -47,8 +47,8 @@ func NewPersistentVolume(obj *corev1.PersistentVolume) *PersistentVolume {
 	}
 }
 
-func (k PersistentVolume) Install() string {
-	l := Literal(k.KubeObject)
+func (k PersistentVolume) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}PersistentVolume := %s
 
@@ -66,7 +66,7 @@ func (k PersistentVolume) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k PersistentVolume) Uninstall() string {

--- a/codify/persistentvolumeclaim.go
+++ b/codify/persistentvolumeclaim.go
@@ -47,8 +47,8 @@ func NewPersistentVolumeClaim(obj *corev1.PersistentVolumeClaim) *PersistentVolu
 	}
 }
 
-func (k PersistentVolumeClaim) Install() string {
-	l := Literal(k.KubeObject)
+func (k PersistentVolumeClaim) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}PersistentVolumeClaim := %s
 
@@ -66,7 +66,7 @@ func (k PersistentVolumeClaim) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k PersistentVolumeClaim) Uninstall() string {

--- a/codify/pod.go
+++ b/codify/pod.go
@@ -47,8 +47,8 @@ func NewPod(obj *corev1.Pod) *Pod {
 	}
 }
 
-func (k Pod) Install() string {
-	l := Literal(k.KubeObject)
+func (k Pod) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}Pod := %s
 
@@ -65,7 +65,7 @@ func (k Pod) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k Pod) Uninstall() string {

--- a/codify/role.go
+++ b/codify/role.go
@@ -46,8 +46,8 @@ func NewRole(obj *rbacv1.Role) *Role {
 	}
 }
 
-func (k Role) Install() string {
-	l := Literal(k.KubeObject)
+func (k Role) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}Role := %s
 
@@ -65,7 +65,7 @@ func (k Role) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "rbacv1")
+	return alias(buf.String(), "rbacv1"), packages
 }
 
 func (k Role) Uninstall() string {

--- a/codify/rolebinding.go
+++ b/codify/rolebinding.go
@@ -46,8 +46,8 @@ func NewRoleBinding(obj *rbacv1.RoleBinding) *RoleBinding {
 	}
 }
 
-func (k RoleBinding) Install() string {
-	l := Literal(k.KubeObject)
+func (k RoleBinding) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}RoleBinding := %s
 
@@ -65,7 +65,7 @@ func (k RoleBinding) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "rbacv1")
+	return alias(buf.String(), "rbacv1"), packages
 }
 
 func (k RoleBinding) Uninstall() string {

--- a/codify/secret.go
+++ b/codify/secret.go
@@ -46,8 +46,8 @@ func NewSecret(obj *corev1.Secret) *Secret {
 	}
 }
 
-func (k Secret) Install() string {
-	l := Literal(k.KubeObject)
+func (k Secret) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}Secret := %s
 
@@ -65,7 +65,7 @@ func (k Secret) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k Secret) Uninstall() string {

--- a/codify/service.go
+++ b/codify/service.go
@@ -47,8 +47,8 @@ func NewService(obj *corev1.Service) *Service {
 	}
 }
 
-func (k Service) Install() string {
-	l := Literal(k.KubeObject)
+func (k Service) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}Service := %s
 
@@ -66,7 +66,7 @@ func (k Service) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k Service) Uninstall() string {

--- a/codify/serviceaccount.go
+++ b/codify/serviceaccount.go
@@ -46,8 +46,8 @@ func NewServiceAccount(obj *corev1.ServiceAccount) *ServiceAccount {
 	}
 }
 
-func (k ServiceAccount) Install() string {
-	l := Literal(k.KubeObject)
+func (k ServiceAccount) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}ServiceAccount := %s
 
@@ -65,7 +65,7 @@ func (k ServiceAccount) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "corev1")
+	return alias(buf.String(), "corev1"), packages
 }
 
 func (k ServiceAccount) Uninstall() string {

--- a/codify/statefulset.go
+++ b/codify/statefulset.go
@@ -47,8 +47,8 @@ func NewStatefulSet(obj *appsv1.StatefulSet) *StatefulSet {
 	}
 }
 
-func (k StatefulSet) Install() string {
-	l := Literal(k.KubeObject)
+func (k StatefulSet) Install() (string, []string) {
+	l, packages := Literal(k.KubeObject)
 	install := fmt.Sprintf(`
 	{{ .GoName }}StatefulSet := %s
 
@@ -64,7 +64,7 @@ func (k StatefulSet) Install() string {
 	if err != nil {
 		logger.Debug(err.Error())
 	}
-	return alias(buf.String(), "appsv1")
+	return alias(buf.String(), "appsv1"), packages
 }
 
 func (k StatefulSet) Uninstall() string {

--- a/embed_main.go
+++ b/embed_main.go
@@ -52,14 +52,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	{{ .Packages }}
 
-	"github.com/hexops/valast"
 	"github.com/kris-nova/naml"
 	"k8s.io/client-go/kubernetes"
 )

--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,6 @@ require (
 	k8s.io/client-go v0.21.3
 	sigs.k8s.io/kind v0.11.1
 )
+
+replace github.com/hexops/valast => github.com/fkautz/valast v1.4.1-0.20210806063143-f33a97256bcb
+

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fkautz/valast v1.4.1-0.20210806063143-f33a97256bcb h1:huiIBlgdJwsLDOgdEYxIFtAUNm9wZePNfmFKnuiiGYE=
+github.com/fkautz/valast v1.4.1-0.20210806063143-f33a97256bcb/go.mod h1:uVjKZ0smVuYlgCSPz9NRi5A04sl7lp6GtFWsROKDgEs=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=

--- a/src/main.go.tpl
+++ b/src/main.go.tpl
@@ -26,14 +26,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	{{ .Packages }}
 
-	"github.com/hexops/valast"
 	"github.com/kris-nova/naml"
 	"k8s.io/client-go/kubernetes"
 )

--- a/vendor/golang.org/x/tools/go/packages/external.go
+++ b/vendor/golang.org/x/tools/go/packages/external.go
@@ -12,10 +12,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	exec "golang.org/x/sys/execabs"
 	"os"
 	"strings"
-
-	exec "golang.org/x/sys/execabs"
 )
 
 // The Driver Protocol

--- a/vendor/golang.org/x/tools/internal/gocommand/invoke.go
+++ b/vendor/golang.org/x/tools/internal/gocommand/invoke.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	exec "golang.org/x/sys/execabs"
 	"io"
 	"os"
 	"regexp"
@@ -16,8 +17,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	exec "golang.org/x/sys/execabs"
 
 	"golang.org/x/tools/internal/event"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/google/gofuzz
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/openapiv2
-# github.com/hexops/valast v1.4.0
+# github.com/hexops/valast v1.4.0 => github.com/fkautz/valast v1.4.1-0.20210806063143-f33a97256bcb
 ## explicit
 github.com/hexops/valast
 # github.com/imdario/mergo v0.3.5
@@ -405,3 +405,4 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/hexops/valast => github.com/fkautz/valast v1.4.1-0.20210806063143-f33a97256bcb


### PR DESCRIPTION
This patch dynamically generates package imports

An example:

```go
        "github.com/hexops/valast"
        appsv1 "k8s.io/api/apps/v1"
        corev1 "k8s.io/api/core/v1"
        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
        "k8s.io/apimachinery/pkg/types"
        "k8s.io/apimachinery/pkg/util/intstr"
```

One caveat, valast is currently forked to `github.com/fkautz/valast`. I will try to upstream the patch and see if they take it. Otherwise, we can maintain a fork with necessary changes.

Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>